### PR TITLE
Add ordered search for mentee

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,8 @@ django-heroku = "*"
 dj-database-url = "*"
 django-mailgun = "*"
 django-json-widget = "*"
-fuzzywuzzy[speedup] = "*"
+fuzzywuzzy = "*"
+python-Levenshtein-wheels = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ django-heroku = "*"
 dj-database-url = "*"
 django-mailgun = "*"
 django-json-widget = "*"
+fuzzywuzzy[speedup] = "*"
 
 [requires]
 python_version = "3.8"

--- a/matching/match_utils.py
+++ b/matching/match_utils.py
@@ -1,4 +1,7 @@
-
+from fuzzywuzzy import fuzz
+from fuzzywuzzy import process
+from collections import namedtuple
+from operator import  attrgetter
 
 from .models import Mentee, Mentor
 
@@ -14,3 +17,29 @@ Health_mentors = Mentor.objects.raw('SELECT * FROM matching_mentee WHERE Career_
 business_jobs = ['Accounting','Banking', 'Capital Markets', 'Entrepreneurship', 'Financial Services', 'Human Resources','Insurance', 'Investment Banking/Management', 'Management Consulting', 'Marketing and Advertising', 'Market Research', 'Venture Capital and Private Equity']
 Bus_mentees = Mentee.objects.raw('SELECT * FROM matching_mentee WHERE Career_Field in %s', [business_jobs])
 Bus_mentors = Mentor.objects.raw('SELECT * FROM matching_mentee WHERE Career_Field in %s', [business_jobs])
+
+
+#differense between mentee and mentor
+matching_fields = ['Hobbies','Barriers']
+
+def calculate_diff(m):
+  menteeAttr = m.other_attributes
+  l = []
+  for mr in Mentor.objects.all():
+    mentor_ratio=0
+    mentorAttr = mr.other_attributes
+
+    for wr in matching_fields:
+      menteeValue = menteeAttr[wr]
+      mentorValue = mentorAttr[wr]
+      ratio=fuzz.ratio(menteeValue,mentorValue)
+      mentor_ratio+=ratio
+
+    mentor_ratio/= len(matching_fields)
+    Entry = namedtuple('Entry','r m')
+    entry = Entry(mentor_ratio,mr)
+    l.append(entry)
+
+  l.sort(key=attrgetter('r'), reverse=True)
+  return [x[1] for x in l]
+  #can also return list of tuples(ratio, mentor)

--- a/matching/match_utils.py
+++ b/matching/match_utils.py
@@ -32,7 +32,7 @@ def calculate_diff(m):
     for wr in matching_fields:
       menteeValue = menteeAttr[wr]
       mentorValue = mentorAttr[wr]
-      ratio=fuzz.ratio(menteeValue,mentorValue)
+      ratio=fuzz.token_set_ratio(menteeValue,mentorValue)
       mentor_ratio+=ratio
 
     mentor_ratio/= len(matching_fields)


### PR DESCRIPTION
Usage:
from .match_utils import calculate_diff
 list =calculate_diff(mentee)

return: ordered  in descending order list of mentors for passed mentee
It is possible to return ordered tuples (ration, mentor) instead

- Next steps: clarify matching keys are same or not
- config + weight for each ratio ?